### PR TITLE
Update runners from macos-12 to macos-13

### DIFF
--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -226,7 +226,7 @@ jobs:
   build_macos:
     name: MacOS ${{ inputs.python_version }} universal2 ${{ matrix.distribution }} (build)
     if: ${{ contains(inputs.platforms, 'macos') }}
-    runs-on: macos-12
+    runs-on: macos-13
     strategy:
       fail-fast: false
       matrix:
@@ -268,10 +268,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-12, macos-14 ]
+        os: [ macos-13, macos-14 ]
         distribution: [full, headless]
         include:
-          - os: macos-12
+          - os: macos-13
             arch: x86_64
           - os: macos-14
             arch: arm64

--- a/.github/workflows/repackage_graalpy.yml
+++ b/.github/workflows/repackage_graalpy.yml
@@ -97,7 +97,7 @@ jobs:
         arch: [x86_64, aarch64]
         include:
           - arch: x86_64
-            runner: macos-12
+            runner: macos-13
           - arch: aarch64
             runner: macos-14
 

--- a/.github/workflows/repackage_pypy.yml
+++ b/.github/workflows/repackage_pypy.yml
@@ -100,7 +100,7 @@ jobs:
         arch: [x86_64, aarch64]
         include:
           - arch: x86_64
-            runner: macos-12
+            runner: macos-13
           - arch: aarch64
             runner: macos-14
 


### PR DESCRIPTION
For upcoming deprecations: https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/