### PR TITLE
Disable UBSAN: add -fno-sanitize=undefined to Linux builds

### DIFF
--- a/scripts/build_linux_zig.sh
+++ b/scripts/build_linux_zig.sh
@@ -48,8 +48,8 @@ if [[ "${ARCH}" == "riscv64" ]]; then
 fi
 
 export ZIG_FLAGS=""
-export CFLAGS="-I${DEPSDIR}/include"
-export CPPFLAGS="-I${DEPSDIR}/include"
+export CFLAGS="-fno-sanitize=undefined -I${DEPSDIR}/include"
+export CPPFLAGS="-fno-sanitize=undefined -I${DEPSDIR}/include"
 export CXXFLAGS="${CPPFLAGS}"
 export LDFLAGS="-L${DEPSDIR}/lib"
 export PKG_CONFIG_PATH="${DEPSDIR}/lib/pkgconfig:${DEPSDIR}/share/pkgconfig"


### PR DESCRIPTION
https://github.com/ziglang/zig/wiki/zig-cc-compatibility-with-clang#ubsan-and-sigill-illegal-instruction
UBSAN introduces `brk` instructions in libffi's dlmalloc, which causes issues with the `aiortc` package.