### PR TITLE
Reduce vmactions verbosity

### DIFF
--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -341,9 +341,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Start VM
-        uses: vmactions/freebsd-vm@v1
+        uses: bjia56/freebsd-vm@nfs
         with:
-          sync: sshfs
+          sync: nfs
           release: ${{ steps.parse_release.outputs.release }}
           prepare: |
             pkg install -y cmake bash wget patch git zip python3 autoconf automake libtool gettext bison pkgconf gmake gperf patchelf texinfo
@@ -407,9 +407,9 @@ jobs:
           path: ./python/
 
       - name: Start VM
-        uses: vmactions/freebsd-vm@v1
+        uses: bjia56/freebsd-vm@nfs
         with:
-          sync: sshfs
+          sync: nfs
           release: ${{ steps.parse_release.outputs.release }}
           prepare: |
             pkg install -y bash
@@ -457,9 +457,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Start VM
-        uses: vmactions/solaris-vm@v1
+        uses: bjia56/solaris-vm@nfs
         with:
-          sync: sshfs
+          sync: nfs
           release: ${{ steps.parse_release.outputs.release }}
           prepare: |
             pkg install --accept cmake git autoconf automake libtool bison gperf gcc pkg-config python-39
@@ -522,9 +522,9 @@ jobs:
           path: ./python/
 
       - name: Start VM
-        uses: vmactions/solaris-vm@v1
+        uses: bjia56/solaris-vm@nfs
         with:
-          sync: sshfs
+          sync: nfs
           release: ${{ steps.parse_release.outputs.release }}
 
       - name: Test in VM

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -352,10 +352,10 @@ jobs:
         shell: freebsd {0}
         run: |
           cd ${{ github.workspace }}
-          export RUN_TESTS="${RUN_TESTS}"
-          export DEBUG_CI="${DEBUG_CI}"
-          export VERBOSE_CI="${VERBOSE_CI}"
-          export PORTABLE_PYTHON_BUILDSYSTEM_BRANCH="${PORTABLE_PYTHON_BUILDSYSTEM_BRANCH}"
+          export RUN_TESTS="${{ env.RUN_TESTS }}"
+          export DEBUG_CI="${{ env.DEBUG_CI }}"
+          export VERBOSE_CI="${{ env.VERBOSE_CI }}"
+          export PORTABLE_PYTHON_BUILDSYSTEM_BRANCH="${{ env.PORTABLE_PYTHON_BUILDSYSTEM_BRANCH }}"
           export PLATFORM="freebsd${{ matrix.release }}"
           bash ./scripts/build_freebsd.sh x86_64 ${{ inputs.python_version }} ${{ matrix.distribution }}
 
@@ -469,10 +469,10 @@ jobs:
         shell: solaris {0}
         run: |
           cd ${{ github.workspace }}
-          export RUN_TESTS="${RUN_TESTS}"
-          export DEBUG_CI="${DEBUG_CI}"
-          export VERBOSE_CI="${VERBOSE_CI}"
-          export PORTABLE_PYTHON_BUILDSYSTEM_BRANCH="${PORTABLE_PYTHON_BUILDSYSTEM_BRANCH}"
+          export RUN_TESTS="${{ env.RUN_TESTS }}"
+          export DEBUG_CI="${{ env.DEBUG_CI }}"
+          export VERBOSE_CI="${{ env.VERBOSE_CI }}"
+          export PORTABLE_PYTHON_BUILDSYSTEM_BRANCH="${{ env.PORTABLE_PYTHON_BUILDSYSTEM_BRANCH }}"
           export PLATFORM="solaris${{ matrix.release }}"
           bash ./scripts/build_solaris.sh x86_64 ${{ inputs.python_version }} ${{ matrix.distribution }}
 

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -351,6 +351,7 @@ jobs:
       - name: Build in VM
         shell: freebsd {0}
         run: |
+          cd ${{ github.workspace }}
           export RUN_TESTS="${RUN_TESTS}"
           export DEBUG_CI="${DEBUG_CI}"
           export VERBOSE_CI="${VERBOSE_CI}"
@@ -416,6 +417,7 @@ jobs:
       - name: Test in VM
         shell: freebsd {0}
         run: |
+          cd ${{ github.workspace }}
           cat > /tmp/test.sh <<EOF
             unzip python/python-${{ matrix.distribution }}-${{ inputs.python_version }}-freebsd${{ matrix.release }}-x86_64.zip
 
@@ -466,6 +468,7 @@ jobs:
       - name: Build in VM
         shell: solaris {0}
         run: |
+          cd ${{ github.workspace }}
           export RUN_TESTS="${RUN_TESTS}"
           export DEBUG_CI="${DEBUG_CI}"
           export VERBOSE_CI="${VERBOSE_CI}"
@@ -527,6 +530,7 @@ jobs:
       - name: Test in VM
         shell: solaris {0}
         run: |
+          cd ${{ github.workspace }}
           cat > /tmp/test.sh <<EOF
             unzip python/python-${{ matrix.distribution }}-${{ inputs.python_version }}-solaris${{ matrix.release }}-x86_64.zip
 

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -346,7 +346,7 @@ jobs:
           sync: sshfs
           release: ${{ steps.parse_release.outputs.release }}
           prepare: |
-            pkg install -y cmake bash wget patch git zip python3 autoconf automake libtool gettext bison pkgconf gmake gperf patchelf
+            pkg install -y cmake bash wget patch git zip python3 autoconf automake libtool gettext bison pkgconf gmake gperf patchelf texinfo
 
       - name: Build in VM
         shell: freebsd {0}

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -352,11 +352,11 @@ jobs:
         shell: freebsd {0}
         run: |
           cd ${{ github.workspace }}
-          export RUN_TESTS="${{ env.RUN_TESTS }}"
-          export DEBUG_CI="${{ env.DEBUG_CI }}"
-          export VERBOSE_CI="${{ env.VERBOSE_CI }}"
-          export PORTABLE_PYTHON_BUILDSYSTEM_BRANCH="${{ env.PORTABLE_PYTHON_BUILDSYSTEM_BRANCH }}"
-          export PLATFORM="freebsd${{ matrix.release }}"
+          setenv RUN_TESTS "${{ env.RUN_TESTS }}"
+          setenv DEBUG_CI "${{ env.DEBUG_CI }}"
+          setenv VERBOSE_CI "${{ env.VERBOSE_CI }}"
+          setenv PORTABLE_PYTHON_BUILDSYSTEM_BRANCH "${{ env.PORTABLE_PYTHON_BUILDSYSTEM_BRANCH }}"
+          setenv PLATFORM "freebsd${{ matrix.release }}"
           bash ./scripts/build_freebsd.sh x86_64 ${{ inputs.python_version }} ${{ matrix.distribution }}
 
       - name: Interactive debugging

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -347,6 +347,7 @@ jobs:
           release: ${{ steps.parse_release.outputs.release }}
           prepare: |
             pkg install -y cmake bash wget patch git zip python3 autoconf automake libtool gettext bison pkgconf gmake gperf patchelf texinfo
+            chsh -s /usr/local/bin/bash root
 
       - name: Build in VM
         shell: freebsd {0}
@@ -413,26 +414,24 @@ jobs:
           release: ${{ steps.parse_release.outputs.release }}
           prepare: |
             pkg install -y bash
+            chsh -s /usr/local/bin/bash root
 
       - name: Test in VM
         shell: freebsd {0}
         run: |
           cd ${{ github.workspace }}
-          cat > /tmp/test.sh <<EOF
-            unzip python/python-${{ matrix.distribution }}-${{ inputs.python_version }}-freebsd${{ matrix.release }}-x86_64.zip
+          unzip python/python-${{ matrix.distribution }}-${{ inputs.python_version }}-freebsd${{ matrix.release }}-x86_64.zip
 
-            cd python-${{ matrix.distribution }}-${{ inputs.python_version }}-freebsd${{ matrix.release }}-x86_64
-            chmod +x ./bin/python
-            ./bin/python --version
-            ./bin/python -m sysconfig
-            ./bin/python ${{ github.workspace }}/scripts/test.py
-            ./bin/pip3
+          cd python-${{ matrix.distribution }}-${{ inputs.python_version }}-freebsd${{ matrix.release }}-x86_64
+          chmod +x ./bin/python
+          ./bin/python --version
+          ./bin/python -m sysconfig
+          ./bin/python ${{ github.workspace }}/scripts/test.py
+          ./bin/pip3
 
-            if [[ "${{ inputs.run_tests }}" == "true" ]]; then
-              ./bin/python -m test -v -ulargefile,network,decimal,cpu,subprocess,urlfetch,tzdata --timeout 60
-            fi
-          EOF
-          bash -e /tmp/test.sh
+          if [[ "${{ inputs.run_tests }}" == "true" ]]; then
+            ./bin/python -m test -v -ulargefile,network,decimal,cpu,subprocess,urlfetch,tzdata --timeout 60
+          fi
 
   build_solaris:
     name: Solaris ${{ matrix.release }} ${{ inputs.python_version }} x86_64 ${{ matrix.distribution }} (build)

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -340,17 +340,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build in VM
+      - name: Start VM
         uses: vmactions/freebsd-vm@v1
         with:
-          envs: 'RUN_TESTS DEBUG_CI VERBOSE_CI PORTABLE_PYTHON_BUILDSYSTEM_BRANCH'
-          usesh: true
+          sync: sshfs
           release: ${{ steps.parse_release.outputs.release }}
           prepare: |
             pkg install -y cmake bash wget patch git zip python3 autoconf automake libtool gettext bison pkgconf gmake gperf patchelf
-          run: |
-            export PLATFORM=freebsd${{ matrix.release }}
-            bash ./scripts/build_freebsd.sh x86_64 ${{ inputs.python_version }} ${{ matrix.distribution }}
+
+      - name: Build in VM
+        shell: freebsd {0}
+        run: |
+          export RUN_TESTS="${RUN_TESTS}"
+          export DEBUG_CI="${DEBUG_CI}"
+          export VERBOSE_CI="${VERBOSE_CI}"
+          export PORTABLE_PYTHON_BUILDSYSTEM_BRANCH="${PORTABLE_PYTHON_BUILDSYSTEM_BRANCH}"
+          export PLATFORM="freebsd${{ matrix.release }}"
+          bash ./scripts/build_freebsd.sh x86_64 ${{ inputs.python_version }} ${{ matrix.distribution }}
 
       - name: Interactive debugging
         if: ${{ always() && inputs.debug_interactive }}
@@ -399,31 +405,32 @@ jobs:
           name: python-freebsd${{ matrix.release }}-x86_64-${{ matrix.distribution }}-${{ inputs.python_version }}
           path: ./python/
 
-      - name: Test in VM
+      - name: Start VM
         uses: vmactions/freebsd-vm@v1
         with:
-          envs: 'RUN_TESTS DEBUG_CI VERBOSE_CI PORTABLE_PYTHON_BUILDSYSTEM_BRANCH'
-          usesh: true
-          copyback: false
+          sync: sshfs
           release: ${{ steps.parse_release.outputs.release }}
           prepare: |
             pkg install -y bash
-          run: |
-            cat > /tmp/test.sh <<EOF
-              unzip python/python-${{ matrix.distribution }}-${{ inputs.python_version }}-freebsd${{ matrix.release }}-x86_64.zip
 
-              cd python-${{ matrix.distribution }}-${{ inputs.python_version }}-freebsd${{ matrix.release }}-x86_64
-              chmod +x ./bin/python
-              ./bin/python --version
-              ./bin/python -m sysconfig
-              ./bin/python ${{ github.workspace }}/scripts/test.py
-              ./bin/pip3
+      - name: Test in VM
+        shell: freebsd {0}
+        run: |
+          cat > /tmp/test.sh <<EOF
+            unzip python/python-${{ matrix.distribution }}-${{ inputs.python_version }}-freebsd${{ matrix.release }}-x86_64.zip
 
-              if [[ "${{ inputs.run_tests }}" == "true" ]]; then
-                ./bin/python -m test -v -ulargefile,network,decimal,cpu,subprocess,urlfetch,tzdata --timeout 60
-              fi
-            EOF
-            bash -e /tmp/test.sh
+            cd python-${{ matrix.distribution }}-${{ inputs.python_version }}-freebsd${{ matrix.release }}-x86_64
+            chmod +x ./bin/python
+            ./bin/python --version
+            ./bin/python -m sysconfig
+            ./bin/python ${{ github.workspace }}/scripts/test.py
+            ./bin/pip3
+
+            if [[ "${{ inputs.run_tests }}" == "true" ]]; then
+              ./bin/python -m test -v -ulargefile,network,decimal,cpu,subprocess,urlfetch,tzdata --timeout 60
+            fi
+          EOF
+          bash -e /tmp/test.sh
 
   build_solaris:
     name: Solaris ${{ matrix.release }} ${{ inputs.python_version }} x86_64 ${{ matrix.distribution }} (build)
@@ -447,18 +454,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build in VM
+      - name: Start VM
         uses: vmactions/solaris-vm@v1
         with:
-          envs: 'RUN_TESTS DEBUG_CI VERBOSE_CI PORTABLE_PYTHON_BUILDSYSTEM_BRANCH'
-          usesh: true
+          sync: sshfs
           release: ${{ steps.parse_release.outputs.release }}
           prepare: |
             pkg install --accept cmake git autoconf automake libtool bison gperf gcc pkg-config python-39
             ln -sf /usr/bin/python3.9 /usr/bin/python3
-          run: |
-            export PLATFORM=solaris${{ matrix.release }}
-            bash ./scripts/build_solaris.sh x86_64 ${{ inputs.python_version }} ${{ matrix.distribution }}
+
+      - name: Build in VM
+        shell: solaris {0}
+        run: |
+          export RUN_TESTS="${RUN_TESTS}"
+          export DEBUG_CI="${DEBUG_CI}"
+          export VERBOSE_CI="${VERBOSE_CI}"
+          export PORTABLE_PYTHON_BUILDSYSTEM_BRANCH="${PORTABLE_PYTHON_BUILDSYSTEM_BRANCH}"
+          export PLATFORM="solaris${{ matrix.release }}"
+          bash ./scripts/build_solaris.sh x86_64 ${{ inputs.python_version }} ${{ matrix.distribution }}
 
       - name: Interactive debugging
         if: ${{ always() && inputs.debug_interactive }}
@@ -505,29 +518,30 @@ jobs:
           name: python-solaris${{ matrix.release }}-x86_64-${{ matrix.distribution }}-${{ inputs.python_version }}
           path: ./python/
 
-      - name: Test in VM
+      - name: Start VM
         uses: vmactions/solaris-vm@v1
         with:
-          envs: 'RUN_TESTS DEBUG_CI VERBOSE_CI PORTABLE_PYTHON_BUILDSYSTEM_BRANCH'
-          usesh: true
-          copyback: false
+          sync: sshfs
           release: ${{ steps.parse_release.outputs.release }}
-          run: |
-            cat > /tmp/test.sh <<EOF
-              unzip python/python-${{ matrix.distribution }}-${{ inputs.python_version }}-solaris${{ matrix.release }}-x86_64.zip
 
-              cd python-${{ matrix.distribution }}-${{ inputs.python_version }}-solaris${{ matrix.release }}-x86_64
-              chmod +x ./bin/python
-              ./bin/python --version
-              ./bin/python -m sysconfig
-              ./bin/python ${{ github.workspace }}/scripts/test.py
-              ./bin/pip3
+      - name: Test in VM
+        shell: solaris {0}
+        run: |
+          cat > /tmp/test.sh <<EOF
+            unzip python/python-${{ matrix.distribution }}-${{ inputs.python_version }}-solaris${{ matrix.release }}-x86_64.zip
 
-              if [[ "${{ inputs.run_tests }}" == "true" ]]; then
-                ./bin/python -m test -v -ulargefile,network,decimal,cpu,subprocess,urlfetch,tzdata --timeout 60
-              fi
-            EOF
-            bash -e /tmp/test.sh
+            cd python-${{ matrix.distribution }}-${{ inputs.python_version }}-solaris${{ matrix.release }}-x86_64
+            chmod +x ./bin/python
+            ./bin/python --version
+            ./bin/python -m sysconfig
+            ./bin/python ${{ github.workspace }}/scripts/test.py
+            ./bin/pip3
+
+            if [[ "${{ inputs.run_tests }}" == "true" ]]; then
+              ./bin/python -m test -v -ulargefile,network,decimal,cpu,subprocess,urlfetch,tzdata --timeout 60
+            fi
+          EOF
+          bash -e /tmp/test.sh
 
   build_cosmo:
     name: Cosmopolitan ${{ inputs.python_version }} (build)

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -352,11 +352,11 @@ jobs:
         shell: freebsd {0}
         run: |
           cd ${{ github.workspace }}
-          setenv RUN_TESTS "${{ env.RUN_TESTS }}"
-          setenv DEBUG_CI "${{ env.DEBUG_CI }}"
-          setenv VERBOSE_CI "${{ env.VERBOSE_CI }}"
-          setenv PORTABLE_PYTHON_BUILDSYSTEM_BRANCH "${{ env.PORTABLE_PYTHON_BUILDSYSTEM_BRANCH }}"
-          setenv PLATFORM "freebsd${{ matrix.release }}"
+          export RUN_TESTS="${{ env.RUN_TESTS }}"
+          export DEBUG_CI="${{ env.DEBUG_CI }}"
+          export VERBOSE_CI="${{ env.VERBOSE_CI }}"
+          export PORTABLE_PYTHON_BUILDSYSTEM_BRANCH="${{ env.PORTABLE_PYTHON_BUILDSYSTEM_BRANCH }}"
+          export PLATFORM="freebsd${{ matrix.release }}"
           bash ./scripts/build_freebsd.sh x86_64 ${{ inputs.python_version }} ${{ matrix.distribution }}
 
       - name: Interactive debugging

--- a/scripts/build_freebsd.sh
+++ b/scripts/build_freebsd.sh
@@ -119,7 +119,7 @@ echo "::group::bzip2"
 cd ${BUILDDIR}
 
 wget --no-verbose -O bzip2.tar.gz https://github.com/commontk/bzip2/tarball/master
-tar --no-same-permissions --no-same-owner -xf bzip2*.tar.gz
+tar -xf bzip2*.tar.gz
 rm *.tar.gz
 cd commontk-bzip2*
 mkdir build
@@ -375,7 +375,7 @@ fi
 ldconfig -i -m -v ${DEPSDIR}/lib
 
 wget --no-verbose -O portable-python-cmake-buildsystem.tar.gz https://github.com/bjia56/portable-python-cmake-buildsystem/tarball/${CMAKE_BUILDSYSTEM_BRANCH}
-tar --no-same-permissions --no-same-owner -xf portable-python-cmake-buildsystem.tar.gz
+tar -xf portable-python-cmake-buildsystem.tar.gz
 rm *.tar.gz
 mv *portable-python-cmake-buildsystem* portable-python-cmake-buildsystem
 mkdir python-build

--- a/scripts/build_freebsd.sh
+++ b/scripts/build_freebsd.sh
@@ -119,7 +119,7 @@ echo "::group::bzip2"
 cd ${BUILDDIR}
 
 wget --no-verbose -O bzip2.tar.gz https://github.com/commontk/bzip2/tarball/master
-tar -xf bzip2*.tar.gz
+tar --no-same-permissions --no-same-owner -xf bzip2*.tar.gz
 rm *.tar.gz
 cd commontk-bzip2*
 mkdir build
@@ -375,7 +375,7 @@ fi
 ldconfig -i -m -v ${DEPSDIR}/lib
 
 wget --no-verbose -O portable-python-cmake-buildsystem.tar.gz https://github.com/bjia56/portable-python-cmake-buildsystem/tarball/${CMAKE_BUILDSYSTEM_BRANCH}
-tar -xf portable-python-cmake-buildsystem.tar.gz
+tar --no-same-permissions --no-same-owner -xf portable-python-cmake-buildsystem.tar.gz
 rm *.tar.gz
 mv *portable-python-cmake-buildsystem* portable-python-cmake-buildsystem
 mkdir python-build

--- a/scripts/build_solaris.sh
+++ b/scripts/build_solaris.sh
@@ -28,7 +28,7 @@ echo "::group::autoconf"
 cd ${BUILDDIR}
 
 wget https://ftp.gnu.org/gnu/autoconf/autoconf-2.70.tar.gz
-gtar --no-same-permissions --no-same-owner -xf autoconf-2.70.tar.gz
+gtar xf autoconf-2.70.tar.gz
 cd autoconf-2.70
 ./configure
 gmake -j4
@@ -142,7 +142,7 @@ echo "::group::bzip2"
 cd ${BUILDDIR}
 
 wget --no-verbose -O bzip2.tar.gz https://github.com/commontk/bzip2/tarball/master
-gtar --no-same-permissions --no-same-owner -xf bzip2*.tar.gz
+gtar -xf bzip2*.tar.gz
 rm *.tar.gz
 cd commontk-bzip2*
 mkdir build
@@ -408,7 +408,7 @@ else
 fi
 
 wget --no-verbose -O portable-python-cmake-buildsystem.tar.gz https://github.com/bjia56/portable-python-cmake-buildsystem/tarball/${CMAKE_BUILDSYSTEM_BRANCH}
-gtar --no-same-permissions --no-same-owner -xf portable-python-cmake-buildsystem.tar.gz
+gtar -xf portable-python-cmake-buildsystem.tar.gz
 rm *.tar.gz
 mv *portable-python-cmake-buildsystem* portable-python-cmake-buildsystem
 mkdir python-build

--- a/scripts/build_solaris.sh
+++ b/scripts/build_solaris.sh
@@ -28,7 +28,7 @@ echo "::group::autoconf"
 cd ${BUILDDIR}
 
 wget https://ftp.gnu.org/gnu/autoconf/autoconf-2.70.tar.gz
-gtar xf autoconf-2.70.tar.gz
+gtar --no-same-permissions --no-same-owner -xf autoconf-2.70.tar.gz
 cd autoconf-2.70
 ./configure
 gmake -j4
@@ -142,7 +142,7 @@ echo "::group::bzip2"
 cd ${BUILDDIR}
 
 wget --no-verbose -O bzip2.tar.gz https://github.com/commontk/bzip2/tarball/master
-gtar -xf bzip2*.tar.gz
+gtar --no-same-permissions --no-same-owner -xf bzip2*.tar.gz
 rm *.tar.gz
 cd commontk-bzip2*
 mkdir build
@@ -408,7 +408,7 @@ else
 fi
 
 wget --no-verbose -O portable-python-cmake-buildsystem.tar.gz https://github.com/bjia56/portable-python-cmake-buildsystem/tarball/${CMAKE_BUILDSYSTEM_BRANCH}
-gtar -xf portable-python-cmake-buildsystem.tar.gz
+gtar --no-same-permissions --no-same-owner -xf portable-python-cmake-buildsystem.tar.gz
 rm *.tar.gz
 mv *portable-python-cmake-buildsystem* portable-python-cmake-buildsystem
 mkdir python-build

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -33,7 +33,7 @@ if [[ "${PLATFORM}" == "solaris"* ]]; then
     #set -x
     file="$1"
     download_and_verify $file
-    gtar --no-same-permissions --no-same-owner -xf $file
+    gtar --no-same-permissions -xf $file
     rm $file
     #set +x
   }
@@ -42,7 +42,7 @@ else
     #set -x
     file="$1"
     download_and_verify $file
-    tar --no-same-permissions --no-same-owner -xf $file
+    tar --no-same-permissions -xf $file
     rm $file
     #set +x
   }

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -33,7 +33,7 @@ if [[ "${PLATFORM}" == "solaris"* ]]; then
     #set -x
     file="$1"
     download_and_verify $file
-    gtar -xf $file
+    gtar --no-same-permissions -xf $file
     rm $file
     #set +x
   }
@@ -42,7 +42,7 @@ else
     #set -x
     file="$1"
     download_and_verify $file
-    tar -xf $file
+    tar --no-same-permissions -xf $file
     rm $file
     #set +x
   }

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -33,7 +33,7 @@ if [[ "${PLATFORM}" == "solaris"* ]]; then
     #set -x
     file="$1"
     download_and_verify $file
-    gtar --no-same-permissions -xf $file
+    gtar -xf $file
     rm $file
     #set +x
   }
@@ -42,7 +42,7 @@ else
     #set -x
     file="$1"
     download_and_verify $file
-    tar --no-same-permissions -xf $file
+    tar -xf $file
     rm $file
     #set +x
   }

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -33,7 +33,7 @@ if [[ "${PLATFORM}" == "solaris"* ]]; then
     #set -x
     file="$1"
     download_and_verify $file
-    gtar --no-same-permissions -xf $file
+    gtar --no-same-permissions --no-same-owner -xf $file
     rm $file
     #set +x
   }
@@ -42,7 +42,7 @@ else
     #set -x
     file="$1"
     download_and_verify $file
-    tar --no-same-permissions -xf $file
+    tar --no-same-permissions --no-same-owner -xf $file
     rm $file
     #set +x
   }


### PR DESCRIPTION
Using custom shell avoids long debug output when builds fail 