### PR TITLE
Link freetype statically

### DIFF
--- a/scripts/build_linux_zig.sh
+++ b/scripts/build_linux_zig.sh
@@ -403,7 +403,7 @@ cd ${BUILDDIR}
 
 download_verify_extract freetype-2.13.2.tar.gz
 cd freetype*
-./configure --host=${CHOST} --prefix=${DEPSDIR}
+./configure --host=${CHOST} --disable-shared --prefix=${DEPSDIR}
 make -j4
 make install
 install_license ./docs/FTL.TXT


### PR DESCRIPTION
As discovered in https://github.com/koush/scrypted/pull/1802

Previously, the freetype build enables both static and dynamic libraries by default, so the linker during the Python build can inadvertently choose to use the dynamic library. This change disables the dynamic library build so the static library is preferred.