### PR TITLE
Dynamic handling of GraalPy and PyPy implementation versions

### DIFF
--- a/installers/nodejs/src/graalpy.ts
+++ b/installers/nodejs/src/graalpy.ts
@@ -23,7 +23,14 @@ const DL_ARCH = (() => {
 
 export default class GraalPyInstaller implements IInstaller {
     private pythonMajor: number = 3;
-    private pythonMinor: number = 10;
+    private get pythonMinor(): number {
+        const parentMajor = parseInt(this.parent.major);
+        const parentMinor = parseInt(this.parent.minor);
+        if (parentMajor < 24 || (parentMajor === 24 && parentMinor < 1)) {
+            return 10;
+        }
+        return 11;
+    };
 
     constructor(private parent: IPortablePython) {}
 

--- a/installers/nodejs/src/pypy.ts
+++ b/installers/nodejs/src/pypy.ts
@@ -33,9 +33,12 @@ export default class PyPyInstaller implements IInstaller {
 
     get pythonMinor(): string {
         if (this.parent.distribution === "auto") {
-            if ((parseInt(this.parent.major) > 7) ||
-                (this.parent.major == "7" && parseInt(this.parent.minor) > 3) ||
-                (this.parent.major == "7" && this.parent.minor == "3" && parseInt(this.parent.patch) > 18)) {
+            const parentMajor = parseInt(this.parent.major);
+            const parentMinor = parseInt(this.parent.minor);
+            const parentPatch = parseInt(this.parent.patch);
+            if (parentMajor > 7 ||
+                (parentMajor == 7 && parentMinor > 3) ||
+                (parentMajor == 7 && parentMinor == 3 && parentPatch >= 18)) {
                 return "11";
             }
             return "10";
@@ -66,15 +69,22 @@ export default class PyPyInstaller implements IInstaller {
             throw Error("expected pypy implementation");
         }
 
-        if ((parseInt(this.parent.major) > 7) ||
-            (this.parent.major == "7" && parseInt(this.parent.minor) > 3) ||
-            (this.parent.major == "7" && this.parent.minor == "3" && parseInt(this.parent.patch) > 18)) {
-            // https://pypy.org/posts/2025/02/pypy-v7318-release.html
+        const parentMajor = parseInt(this.parent.major);
+        const parentMinor = parseInt(this.parent.minor);
+        const parentPatch = parseInt(this.parent.patch);
+
+        if (parentMajor > 7 ||
+            (parentMajor == 7 && parentMinor > 3) ||
+            (parentMajor == 7 && parentMinor == 3 && parentPatch > 19)) {
             if (!["auto", "3.11"].includes(this.parent.distribution)) {
                 throw Error("invalid distribution");
             }
-        } else if (this.parent.major == "7" && this.parent.minor == "3" && this.parent.patch == "18") {
+        } else if (parentMajor == 7 && parentMinor == 3 && [18, 19].includes(parentPatch)) {
             if (!["auto", "3.10", "3.11"].includes(this.parent.distribution)) {
+                throw Error("invalid distribution");
+            }
+        } else if (parentMajor == 7 && parentMinor == 3 && parentPatch == 17) {
+            if (!["auto", "3.10"].includes(this.parent.distribution)) {
                 throw Error("invalid distribution");
             }
         } else {

--- a/scripts/repackage_graalpy.sh
+++ b/scripts/repackage_graalpy.sh
@@ -24,6 +24,31 @@ fi
 python3 -m pip install pyclean
 WORKDIR=$(pwd)
 
+function get_version_code() {
+  local semver=$1
+  local major minor patch
+
+  # Split the semver string into components
+  IFS='.' read -r major minor patch <<< "$semver"
+
+  # Validate that major and minor are numbers
+  if [[ ! $major =~ ^[0-9]+$ ]] || [[ ! $minor =~ ^[0-9]+$ ]]; then
+    echo "Invalid version format"
+    return 1
+  fi
+
+  # Apply the conditions
+  if (( major < 24 )); then
+    echo 10
+  elif (( major == 24 && minor < 1 )); then
+    echo 10
+  else
+    echo 11
+  fi
+}
+
+PYTHON_MINOR=$(get_version_code ${GRAALPY_VERSION})
+
 function repackage_graal () {
   DISTRIBUTION=$1
   echo "::group::GraalPy ${DISTRIBUTION}"
@@ -67,7 +92,7 @@ function repackage_graal () {
 
   if [[ "${PLATFORM}" != "windows" ]]; then
     python3 ${WORKDIR}/scripts/patch_pip_script.py ./bin/pip3
-    python3 ${WORKDIR}/scripts/patch_pip_script.py ./bin/pip3.11
+    python3 ${WORKDIR}/scripts/patch_pip_script.py ./bin/pip3.${PYTHON_MINOR}
   fi
 
   cd ${WORKDIR}

--- a/scripts/repackage_pypy.sh
+++ b/scripts/repackage_pypy.sh
@@ -20,6 +20,31 @@ fi
 python3 -m pip install pyclean
 WORKDIR=$(pwd)
 
+function get_version_code() {
+  local semver=$1
+  local major minor patch
+
+  # Split the semver string into components
+  IFS='.' read -r major minor patch <<< "$semver"
+
+  # Validate that major, minor, and patch are numbers
+  if [[ ! $major =~ ^[0-9]+$ ]] || [[ ! $minor =~ ^[0-9]+$ ]] || [[ ! $patch =~ ^[0-9]+$ ]]; then
+    echo "Invalid version format"
+    return 1
+  fi
+
+  # Compare version components
+  if (( major < 7 )) || { (( major == 7 )) && (( minor < 3 )); } || { (( major == 7 )) && (( minor == 3 )) && (( patch < 16 )); }; then
+    echo 9
+  elif (( major == 7 && minor == 3 && patch == 16 )); then
+    echo "9 10"
+  elif (( major == 7 && minor == 3 && patch == 17 )); then
+    echo 10
+  else
+    echo "10 11"
+  fi
+}
+
 function repackage_pypy () {
   DISTRIBUTION=$1
   echo "::group::PyPy ${DISTRIBUTION}"
@@ -82,5 +107,6 @@ function repackage_pypy () {
   echo "::endgroup::"
 }
 
-repackage_pypy 3.10
-repackage_pypy 3.11
+for python_minor in $(get_version_code ${PYPY_VERSION}); do
+  repackage_pypy 3.${python_minor}
+done


### PR DESCRIPTION
Add logic in both installer and build scripts to dynamically select available Python implementation versions based on GraalPy and PyPy release versions.